### PR TITLE
Added benchmark and optimised ParseBytes

### DIFF
--- a/bit_string.go
+++ b/bit_string.go
@@ -3,7 +3,6 @@ package iabconsent
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -37,9 +36,11 @@ type BitString struct {
 // a multiple of 8 bits, we pad the end of the string with 0s.
 func ParseBytes(b []byte) BitString {
 	var buffer bytes.Buffer
+	buffer.Grow(len(b) * 8)
 
 	for _, s := range b {
-		buffer.WriteString(fmt.Sprintf("%08b", s))
+		x := byteToBinary(s)
+		buffer.Write(x[:])
 	}
 
 	return BitString{value: buffer.String()}
@@ -121,4 +122,19 @@ func (b BitString) ParseString(offset, size int) (string, error) {
 		retString = append(retString, string(str+65))
 	}
 	return strings.Join(retString, ""), nil
+}
+
+func byteToBinary(num byte) [8]byte {
+	var b [8]byte
+
+	for i := 7; i >= 0; i-- {
+		if num&1 == 1 {
+			b[i] = '1'
+		} else {
+			b[i] = '0'
+		}
+		num >>= 1
+	}
+
+	return b
 }

--- a/parsed_consent_test.go
+++ b/parsed_consent_test.go
@@ -1,7 +1,9 @@
 package iabconsent
 
 import (
+	"fmt"
 	"sort"
+	"testing"
 
 	"github.com/go-check/check"
 )
@@ -126,3 +128,53 @@ func normalizeParsedConsent(p *ParsedConsent) {
 }
 
 var _ = check.Suite(&ParsedConsentSuite{})
+
+func BenchmarkParse(b *testing.B) {
+	b.ReportAllocs()
+
+	var cases = []struct {
+		Type          consentType
+		EncodedString string
+	}{
+		{
+			Type:          BitField,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAplY",
+		},
+		{
+			Type:          SingleRangeWithSingleID,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAqABAD2AAAAAAAAAAAAAAAAAAAAAAAAAA",
+		},
+		{
+			Type:          SingleRangeWithRange,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAqABgD2AdQAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		},
+		{
+			Type:          MultipleRangesWithSingleID,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAqACAD2AOoAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		},
+		{
+			Type:          MultipleRangesWithRange,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAqACgD2AdUBWQHIAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		},
+		{
+			Type:          MultipleRangesMixed,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAqACAD3AVkByAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		},
+	}
+
+	for _, c := range cases {
+		b.Run(fmt.Sprintf("%d", c.Type), func(b *testing.B) {
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				parsedString, err := Parse(c.EncodedString)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if parsedString == nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The first optimisation is to pre-emptively grow the buffer to the
right size. The second is to more efficiently convert a byte to a zero
padded 8 bit binary string. byteToBinary returns a `[8]byte` instead of a
`[]byte` to prevent it escaping to the heap.

```
benchmark              old ns/op      new ns/op      delta
BenchmarkParse/0-4     5996           2482           -58.61%
BenchmarkParse/1-4     10321          2891           -71.99%
BenchmarkParse/2-4     9658           2963           -69.32%
BenchmarkParse/3-4     10338          3082           -70.19%
BenchmarkParse/4-4     11903          3318           -72.12%
BenchmarkParse/5-4     12563          3176           -74.72%

benchmark              old allocs     new allocs     delta
BenchmarkParse/0-4     40             16             -60.00%
BenchmarkParse/1-4     64             17             -73.44%
BenchmarkParse/2-4     66             17             -74.24%
BenchmarkParse/3-4     70             19             -72.86%
BenchmarkParse/4-4     74             19             -74.32%
BenchmarkParse/5-4     72             19             -73.61%

benchmark              old bytes      new bytes      delta
BenchmarkParse/0-4     1592           1164           -26.88%
BenchmarkParse/1-4     2496           1508           -39.58%
BenchmarkParse/2-4     2512           1508           -39.97%
BenchmarkParse/3-4     2624           1636           -37.65%
BenchmarkParse/4-4     2688           1700           -36.76%
BenchmarkParse/5-4     2640           1636           -38.03%
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/iabconsent/3)
<!-- Reviewable:end -->
