### PR TITLE
Support travis builds of forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 
+go_import_path: github.com/LiveRamp/iabconsent
+
 go:
   - 1.8.x
   - 1.9.x


### PR DESCRIPTION
By default, Travis CI will place source code under
GOPATH/src/github.com/<user>/iabconsent. This results in build problems.
By explicitly specifying the import path, forks of this repo can be
integrated with Travis CI without customizing .travis.yml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/iabconsent/6)
<!-- Reviewable:end -->
