### PR TITLE
Replace panics with errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,14 +8,20 @@
   revision = "20d25e2804050c1cd24a7eea1e7a6447dd0e74ec"
 
 [[projects]]
-  branch = "master"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
   name = "github.com/rupertchen/go-bits"
   packages = ["."]
-  revision = "3b2888c1d57c32dabf11d4394bca1084dc4c18f7"
+  revision = "e6e22cd48e4f78d8fb537a2aa7b63f3debb231cc"
+  version = "v0.2.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "183d07f32ad4d369c583794316cf311baec8c66147b7b5d1ab7f006ff3759636"
+  inputs-digest = "03d067f9290a2ed1e45c957b0437e7503c0c48e67be3aa79429ad3f033a088b1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,6 +2,14 @@
   branch = "v1"
   name = "github.com/go-check/check"
 
+[[constraint]]
+  name = "github.com/pkg/errors"
+  version = "v0.8.0"
+
+[[constraint]]
+  name = "github.com/rupertchen/go-bits"
+  version = "v0.2.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/parse.go
+++ b/parse.go
@@ -108,7 +108,7 @@ func (r *ConsentReader) ReadRangeEntries(n uint) ([]*RangeEntry, error) {
 func Parse(s string) (*ParsedConsent, error) {
 	var b, err = base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "parse consent string")
 	}
 
 	var r = NewConsentReader(b)

--- a/parse_test.go
+++ b/parse_test.go
@@ -95,7 +95,7 @@ func (s *ParseSuite) TestParse2_error(c *check.C) {
 	}{
 		{
 			EncodedString: "//BONJ5bvONJ5bvAMAPyFRAL7AAAAMhuqKklS-gAAAAAAAAAAAAAAAAAAAAAAAAAA",
-			Error:         "illegal base64 data at input byte 0",
+			Error:         "parse consent string: illegal base64 data at input byte 0",
 		},
 		{
 			// base64.RawURLEncoding.EncodeToString([]byte("10011010110110101"))

--- a/parse_test.go
+++ b/parse_test.go
@@ -26,7 +26,9 @@ func (s *ParseSuite) TestConsentReader_ReadInt(c *check.C) {
 
 	var r = iabconsent.NewConsentReader([]byte{0xaa})
 	for _, t := range tests {
-		c.Check(r.ReadInt(t.n), check.Equals, t.expected)
+		var v, err = r.ReadInt(t.n)
+		c.Check(err, check.IsNil)
+		c.Check(v, check.Equals, t.expected)
 	}
 	c.Check(r.HasUnread(), check.Equals, false)
 }
@@ -37,7 +39,9 @@ func (s *ParseSuite) TestConsentReader_ReadTime(c *check.C) {
 	// 15266657115 deci-seconds
 	// 0x38df6b35b deci-seconds (hex)
 	var r = iabconsent.NewConsentReader([]byte{0x38, 0xdf, 0x6b, 0x35, 0xB0})
-	c.Check(r.ReadTime(), check.DeepEquals, time.Unix(1526665711, int64(500*time.Millisecond)).UTC())
+	var v, err = r.ReadTime()
+	c.Check(err, check.IsNil)
+	c.Check(v, check.DeepEquals, time.Unix(1526665711, int64(500*time.Millisecond)).UTC())
 	c.Check(r.NumUnread(), check.Equals, 4)
 }
 
@@ -49,9 +53,14 @@ func (s *ParseSuite) TestConsentReader_ReadString(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	var r = iabconsent.NewConsentReader(b)
-	c.Check(r.ReadString(1), check.Equals, "A")
-	c.Check(r.ReadString(2), check.Equals, "BC")
-	c.Check(r.ReadString(1), check.Equals, "D")
+	var checkString = func(n uint, expected string) {
+		var v, err = r.ReadString(n)
+		c.Check(err, check.IsNil)
+		c.Check(v, check.Equals, expected)
+	}
+	checkString(1, "A")
+	checkString(2, "BC")
+	checkString(1, "D")
 	c.Check(r.HasUnread(), check.Equals, false)
 }
 
@@ -72,7 +81,9 @@ func (s *ParseSuite) TestConsentReader_ReadBitField(c *check.C) {
 
 	var r = iabconsent.NewConsentReader([]byte{0x5a})
 	for _, t := range tests {
-		c.Check(r.ReadBitField(t.n), check.DeepEquals, t.expected)
+		var v, err = r.ReadBitField(t.n)
+		c.Check(err, check.IsNil)
+		c.Check(v, check.DeepEquals, t.expected)
 	}
 	c.Check(r.HasUnread(), check.Equals, false)
 }
@@ -89,12 +100,12 @@ func (s *ParseSuite) TestParse2_error(c *check.C) {
 		{
 			// base64.RawURLEncoding.EncodeToString([]byte("10011010110110101"))
 			EncodedString: "MTAwMTEwMTAxMTAxMTAxMDE",
-			Error:         "index out of range",
+			Error:         ".*index out of range",
 		},
 	}
 
 	for _, t := range tests {
 		_, err := iabconsent.Parse(t.EncodedString)
-		c.Check(err.Error(), check.Equals, t.Error)
+		c.Check(err, check.ErrorMatches, t.Error)
 	}
 }


### PR DESCRIPTION
This change addresses the concerns raised in LiveRamp/iabconsent#5. It
replaces the use of panics with returned errors and introduces breaking
changes to ConsentReader. The returned errors now include stack traces
which can be seen with the "%+v" format verb.

Parse() remains backwards compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/iabconsent/7)
<!-- Reviewable:end -->
