### PR TITLE
Initialize go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/LiveRamp/iabconsent
+
+go 1.12
+
+require (
+	github.com/go-check/check v0.0.0-20161208181325-20d25e280405
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/pkg/errors v0.8.0
+	github.com/rupertchen/go-bits v0.2.0
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/go-check/check v0.0.0-20161208181325-20d25e280405 h1:0kdUKH22y+PT7ZITTEcrrHsQfGmpi4fj0XGyoDe/krQ=
+github.com/go-check/check v0.0.0-20161208181325-20d25e280405/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/rupertchen/go-bits v0.2.0 h1:B5+B70H4vWgwMppvo3wiYtwgN1j9m2nD9DJnnMqGcbQ=
+github.com/rupertchen/go-bits v0.2.0/go.mod h1:V1n1fOC+mPsmLRcRQ5Esgi7CMdsPNeWNz4nVGm+DMJc=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Run `go mod init` and `go mod tidy` to get preliminary go module support
set up in this repo.

Ran `go test ./...` in the repo root after initializing modules, and
outside of a GOPATH on the host to prove that it's working.

This provides incremental progress towards our go module migration
internally at LiveRamp, but also direct support for anyone using this
repo externally with Go modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/iabconsent/10)
<!-- Reviewable:end -->
