### PR TITLE
Added methods to v2 parsed consent

### DIFF
--- a/v2_parsed_consent.go
+++ b/v2_parsed_consent.go
@@ -260,3 +260,29 @@ const (
 	// - Conduct any other data processing operation allowed under a different purpose under this purpose
 	TechnicallyDeliverAds
 )
+
+// EveryPurposeAllowed returns true iff every purpose number in ps exists in
+// the ParsedConsent, otherwise false.
+func (p *V2ParsedConsent) EveryPurposeAllowed(ps []int) bool {
+	for _, rp := range ps {
+		if !p.PurposesConsent[rp] {
+			return false
+		}
+	}
+	return true
+}
+
+// VendorAllowed returns true if the ParsedConsent contains affirmative consent
+// for VendorID v.
+func (p *V2ParsedConsent) VendorAllowed(v int) bool {
+	if p.IsConsentRangeEncoding {
+		for _, re := range p.ConsentedVendorsRange {
+			if re.StartVendorID <= v && v <= re.EndVendorID {
+				return true
+			}
+		}
+		return false
+	}
+
+	return p.ConsentedVendors[v]
+}

--- a/v2_parsed_consent.go
+++ b/v2_parsed_consent.go
@@ -262,7 +262,7 @@ const (
 )
 
 // EveryPurposeAllowed returns true iff every purpose number in ps exists in
-// the ParsedConsent, otherwise false.
+// the V2ParsedConsent, otherwise false.
 func (p *V2ParsedConsent) EveryPurposeAllowed(ps []int) bool {
 	for _, rp := range ps {
 		if !p.PurposesConsent[rp] {


### PR DESCRIPTION
I've added methods here that do some barebones checking of purposes + consent within the TCF v2 parsed consent.

The business logic here may change quite a bit after discussions with our privacy / data ethics folks, so use with caution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/iabconsent/14)
<!-- Reviewable:end -->
