### PR TITLE
Add more v2 processing logic, tests abound

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -275,8 +275,8 @@ func ParseV2(s string) (*V2ParsedConsent, error) {
 	var r = NewConsentReader(b)
 
 	// This block of code directly describes the format of the payload.
-	// The spec for the consent string can be found here:
 	// https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/47b45ab362515310183bb3572a367b8391ef4613/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#about-the-transparency--consent-string-tc-string
+	// The spec for the consent string can be found here:
 	var p = &V2ParsedConsent{}
 	p.Version, _ = r.ReadInt(6)
 	if p.Version != int(V2) {

--- a/parse.go
+++ b/parse.go
@@ -275,8 +275,8 @@ func ParseV2(s string) (*V2ParsedConsent, error) {
 	var r = NewConsentReader(b)
 
 	// This block of code directly describes the format of the payload.
-	// https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/47b45ab362515310183bb3572a367b8391ef4613/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#about-the-transparency--consent-string-tc-string
 	// The spec for the consent string can be found here:
+	// https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/47b45ab362515310183bb3572a367b8391ef4613/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#about-the-transparency--consent-string-tc-string
 	var p = &V2ParsedConsent{}
 	p.Version, _ = r.ReadInt(6)
 	if p.Version != int(V2) {

--- a/parsed_consent.go
+++ b/parsed_consent.go
@@ -49,6 +49,13 @@ func (p *ParsedConsent) VendorAllowed(v int) bool {
 	return p.ConsentedVendors[v]
 }
 
+// SuitableToProcess is the union of EveryPurposeAllowed(ps) and
+// VendorAllowed(v). It's used to make possible an interface that
+// can be used to check whether its legal to process v1 & v2 strings.
+func (p *ParsedConsent) SuitableToProcess(ps []int, v int) bool {
+	return p.EveryPurposeAllowed(ps) && p.VendorAllowed(v)
+}
+
 // RangeEntry defines an inclusive range of vendor IDs from StartVendorID to
 // EndVendorID.
 type RangeEntry struct {

--- a/parsed_consent_test.go
+++ b/parsed_consent_test.go
@@ -59,4 +59,202 @@ func normalizeParsedConsent(p *iabconsent.ParsedConsent) {
 	})
 }
 
+func (p  *ParsedConsentSuite) TestEveryPurposeAllowed(c *check.C) {
+	var tcs = []struct{
+		purposes []int
+		consent map[int]bool
+		exp bool
+	}{
+		{
+			purposes: []int{1, 2, 3},
+			consent: map[int]bool{1: true, 2: true, 3: true},
+			exp: true,
+		},
+		{
+			purposes: []int{1, 2, 3},
+			consent: map[int]bool{1: true, 2: true, 3: false},
+			exp: false,
+		},
+		{
+			purposes: []int{1, 2, 3},
+			consent: map[int]bool{1: true, 2: true},
+			exp: false,
+		},
+		{
+			purposes: []int{1, 2},
+			consent: map[int]bool{1: true, 2: true, 3: true},
+			exp: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Log(tc)
+
+		var pc = &iabconsent.ParsedConsent{
+			PurposesAllowed: tc.consent,
+		}
+
+		c.Check(pc.EveryPurposeAllowed(tc.purposes), check.Equals, tc.exp)
+	}
+}
+
+func (p  *ParsedConsentSuite) TestVendorAllowed(c *check.C) {
+	var tcs = []struct{
+		vendor int
+		isRange bool
+		entries []*iabconsent.RangeEntry
+		vendors map[int]bool
+		exp bool
+	}{
+		{
+			vendor: 123,
+			isRange: true,
+			entries: []*iabconsent.RangeEntry{
+				{
+					StartVendorID: 100,
+					EndVendorID: 200,
+				},
+			},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			isRange: true,
+			entries: []*iabconsent.RangeEntry{
+				{
+					StartVendorID: 50,
+					EndVendorID: 60,
+				},
+				{
+					StartVendorID: 100,
+					EndVendorID: 200,
+				},
+				{
+					StartVendorID: 250,
+					EndVendorID: 260,
+				},
+			},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			isRange: true,
+			entries: []*iabconsent.RangeEntry{
+				{
+					StartVendorID: 123,
+					EndVendorID: 123,
+				},
+			},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			isRange: true,
+			entries: []*iabconsent.RangeEntry{
+				{
+					StartVendorID: 50,
+					EndVendorID: 60,
+				},
+				{
+					StartVendorID: 250,
+					EndVendorID: 260,
+				},
+			},
+			exp: false,
+		},
+		{
+			vendor: 123,
+			isRange: true,
+			entries: []*iabconsent.RangeEntry{},
+			exp: false,
+		},
+		{
+			vendor: 123,
+			isRange: false,
+			vendors: map[int]bool{123: true},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			isRange: false,
+			vendors: map[int]bool{123: true, 124: true},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			isRange: false,
+			vendors: map[int]bool{122: true, 124: true},
+			exp: false,
+		},
+		{
+			vendor: 123,
+			isRange: false,
+			vendors: map[int]bool{123: false, 124: true},
+			exp: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Log(tc)
+
+		var pc = &iabconsent.ParsedConsent{
+			IsRangeEncoding: tc.isRange,
+			RangeEntries: tc.entries,
+			ConsentedVendors: tc.vendors,
+		}
+
+		c.Check(pc.VendorAllowed(tc.vendor), check.Equals, tc.exp)
+	}
+}
+
+func (v  *ParsedConsentSuite) TestSuitableToProcess(c *check.C) {
+	var tcs = []struct{
+		vendor int
+		purposes []int
+		consentedPurposes map[int]bool
+		consentedVendors map[int]bool
+		exp bool
+	}{
+		{
+			vendor: 123,
+			purposes: []int{1, 2, 3},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: true},
+			consentedVendors: map[int]bool{123: true},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			purposes: []int{1, 2, 3},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: true},
+			consentedVendors: map[int]bool{123: false},
+			exp: false,
+		},
+		{
+			vendor: 123,
+			purposes: []int{1, 2, 3},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: false},
+			consentedVendors: map[int]bool{123: true},
+			exp: false,
+		},
+		{
+			vendor: 123,
+			purposes: []int{1, 2, 3},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: false},
+			consentedVendors: map[int]bool{123: false},
+			exp: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Log(tc)
+
+		var pc = &iabconsent.ParsedConsent{
+			PurposesAllowed: tc.consentedPurposes,
+			ConsentedVendors: tc.consentedVendors,
+		}
+
+		c.Check(pc.SuitableToProcess(tc.purposes, tc.vendor), check.Equals, tc.exp)
+	}
+}
+
 var _ = check.Suite(&ParsedConsentSuite{})

--- a/v2_parsed_consent.go
+++ b/v2_parsed_consent.go
@@ -319,7 +319,7 @@ func inRangeEntries(v int, entries []*RangeEntry) bool {
 }
 
 // SuitableToProcess evaluates if its suitable for a vendor (with a set of
-// required purposes) to process a given request.
+// required purposes allowed on the basis of consent) to process a given request.
 func (p *V2ParsedConsent) SuitableToProcess(ps []int, v int) bool {
 	return p.VendorAllowed(v) &&
 		p.EveryPurposeAllowed(ps) &&

--- a/v2_parsed_consent.go
+++ b/v2_parsed_consent.go
@@ -286,7 +286,7 @@ func (p *V2ParsedConsent) VendorAllowed(v int) bool {
 	return p.ConsentedVendors[v]
 }
 
-// PublisherRestricted returns true if any purpose in |pm| is
+// PublisherRestricted returns true if any purpose in |ps| is
 // Flatly Not Allowed and |v| is covered by that restriction.
 func (p *V2ParsedConsent) PublisherRestricted(ps []int, v int) bool {
 	// Map-ify ps for use in checking pub restrictions.

--- a/v2_parsed_consent_test.go
+++ b/v2_parsed_consent_test.go
@@ -288,6 +288,31 @@ func (v  *V2ParsedConsentSuite) TestSuitableToProcess(c *check.C) {
 					NumEntries: 1,
 					RestrictionsRange: []*iabconsent.RangeEntry{
 						{
+							StartVendorID: 100,
+							EndVendorID: 110,
+						},
+						{
+							StartVendorID: 130,
+							EndVendorID: 140,
+						},
+					},
+				},
+			},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			purposes: []int{1, 2, 3},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: true},
+			consentedVendors: map[int]bool{123: true},
+			numRestrictions: 1,
+			restrictions: []*iabconsent.PubRestrictionEntry{
+				{
+					PurposeID: 3,
+					RestrictionType: iabconsent.PurposeFlatlyNotAllowed,
+					NumEntries: 1,
+					RestrictionsRange: []*iabconsent.RangeEntry{
+						{
 							StartVendorID: 123,
 							EndVendorID: 123,
 						},

--- a/v2_parsed_consent_test.go
+++ b/v2_parsed_consent_test.go
@@ -24,4 +24,329 @@ func (v *V2ParsedConsentSuite) TestNonV2Input(c *check.C) {
 	c.Check(err, check.ErrorMatches, "non-v2 string passed to v2 parse method")
 }
 
+func (v  *V2ParsedConsentSuite) TestEveryPurposeAllowed(c *check.C) {
+	var tcs = []struct{
+		purposes []int
+		consent map[int]bool
+		exp bool
+	}{
+		{
+			purposes: []int{1, 2, 3},
+			consent: map[int]bool{1: true, 2: true, 3: true},
+			exp: true,
+		},
+		{
+			purposes: []int{1, 2, 3},
+			consent: map[int]bool{1: true, 2: true, 3: false},
+			exp: false,
+		},
+		{
+			purposes: []int{1, 2, 3},
+			consent: map[int]bool{1: true, 2: true},
+			exp: false,
+		},
+		{
+			purposes: []int{1, 2},
+			consent: map[int]bool{1: true, 2: true, 3: true},
+			exp: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Log(tc)
+
+		var pc = &iabconsent.V2ParsedConsent{
+			PurposesConsent: tc.consent,
+		}
+
+		c.Check(pc.EveryPurposeAllowed(tc.purposes), check.Equals, tc.exp)
+	}
+}
+
+func (v  *V2ParsedConsentSuite) TestVendorAllowed(c *check.C) {
+	var tcs = []struct{
+		vendor int
+		isRange bool
+		entries []*iabconsent.RangeEntry
+		vendors map[int]bool
+		exp bool
+	}{
+		{
+			vendor: 123,
+			isRange: true,
+			entries: []*iabconsent.RangeEntry{
+				{
+					StartVendorID: 100,
+					EndVendorID: 200,
+				},
+			},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			isRange: true,
+			entries: []*iabconsent.RangeEntry{
+				{
+					StartVendorID: 50,
+					EndVendorID: 60,
+				},
+				{
+					StartVendorID: 100,
+					EndVendorID: 200,
+				},
+				{
+					StartVendorID: 250,
+					EndVendorID: 260,
+				},
+			},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			isRange: true,
+			entries: []*iabconsent.RangeEntry{
+				{
+					StartVendorID: 123,
+					EndVendorID: 123,
+				},
+			},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			isRange: true,
+			entries: []*iabconsent.RangeEntry{
+				{
+					StartVendorID: 50,
+					EndVendorID: 60,
+				},
+				{
+					StartVendorID: 250,
+					EndVendorID: 260,
+				},
+			},
+			exp: false,
+		},
+		{
+			vendor: 123,
+			isRange: true,
+			entries: []*iabconsent.RangeEntry{},
+			exp: false,
+		},
+		{
+			vendor: 123,
+			isRange: false,
+			vendors: map[int]bool{123: true},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			isRange: false,
+			vendors: map[int]bool{123: true, 124: true},
+			exp: true,
+		},
+		{
+			vendor: 123,
+			isRange: false,
+			vendors: map[int]bool{122: true, 124: true},
+			exp: false,
+		},
+		{
+			vendor: 123,
+			isRange: false,
+			vendors: map[int]bool{123: false, 124: true},
+			exp: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Log(tc)
+
+		var pc = &iabconsent.V2ParsedConsent{
+			IsConsentRangeEncoding: tc.isRange,
+			ConsentedVendorsRange: tc.entries,
+			ConsentedVendors: tc.vendors,
+		}
+
+		c.Check(pc.VendorAllowed(tc.vendor), check.Equals, tc.exp)
+	}
+}
+
+func (v  *V2ParsedConsentSuite) TestPublisherRestricted(c *check.C) {
+	var tcs = []struct{
+		purposes []int
+		vendor int
+		numRestrictions int
+		restrictions []*iabconsent.PubRestrictionEntry
+		exp bool
+	}{
+		{
+			purposes: []int{1, 2, 3},
+			vendor: 123,
+			numRestrictions: 0,
+			exp: false,
+		},
+		{
+			purposes: []int{1, 2, 3},
+			vendor: 123,
+			numRestrictions: 1,
+			restrictions: []*iabconsent.PubRestrictionEntry{
+				{
+					PurposeID: 4,
+					RestrictionType: iabconsent.PurposeFlatlyNotAllowed,
+					NumEntries: 1,
+					RestrictionsRange: []*iabconsent.RangeEntry{
+						{
+							StartVendorID: 123,
+							EndVendorID: 123,
+						},
+					},
+				},
+			},
+			exp: false,
+		},
+		{
+			purposes: []int{1, 2, 3},
+			vendor: 123,
+			numRestrictions: 1,
+			restrictions: []*iabconsent.PubRestrictionEntry{
+				{
+					PurposeID: 3,
+					RestrictionType: iabconsent.PurposeFlatlyNotAllowed,
+					NumEntries: 1,
+					RestrictionsRange: []*iabconsent.RangeEntry{
+						{
+							StartVendorID: 123,
+							EndVendorID: 123,
+						},
+					},
+				},
+			},
+			exp: true,
+		},
+		{
+			purposes: []int{1, 2, 3},
+			vendor: 123,
+			numRestrictions: 1,
+			restrictions: []*iabconsent.PubRestrictionEntry{
+				{
+					PurposeID: 3,
+					RestrictionType: iabconsent.RequireConsent,
+					NumEntries: 1,
+					RestrictionsRange: []*iabconsent.RangeEntry{
+						{
+							StartVendorID: 123,
+							EndVendorID: 123,
+						},
+					},
+				},
+			},
+			exp: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Log(tc)
+
+		var pc = &iabconsent.V2ParsedConsent{
+			NumPubRestrictions: tc.numRestrictions,
+			PubRestrictionEntries: tc.restrictions,
+		}
+
+		c.Check(pc.PublisherRestricted(tc.purposes, tc.vendor), check.Equals, tc.exp)
+	}
+}
+
+func (v  *V2ParsedConsentSuite) TestSuitableToProcess(c *check.C) {
+	var tcs = []struct{
+		vendor int
+		purposes []int
+		consentedPurposes map[int]bool
+		consentedVendors map[int]bool
+		numRestrictions int
+		restrictions []*iabconsent.PubRestrictionEntry
+		exp bool
+	}{
+		{
+			vendor: 123,
+			purposes: []int{1, 2, 3},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: true},
+			consentedVendors: map[int]bool{123: true},
+			numRestrictions: 0,
+			exp: true,
+		},
+		{
+			vendor: 123,
+			purposes: []int{1, 2, 3},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: true},
+			consentedVendors: map[int]bool{123: true},
+			numRestrictions: 1,
+			restrictions: []*iabconsent.PubRestrictionEntry{
+				{
+					PurposeID: 3,
+					RestrictionType: iabconsent.PurposeFlatlyNotAllowed,
+					NumEntries: 1,
+					RestrictionsRange: []*iabconsent.RangeEntry{
+						{
+							StartVendorID: 123,
+							EndVendorID: 123,
+						},
+					},
+				},
+			},
+			exp: false,
+		},
+		{
+			vendor: 123,
+			purposes: []int{1, 2, 3},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: true},
+			consentedVendors: map[int]bool{123: false},
+			numRestrictions: 0,
+			exp: false,
+		},
+		{
+			vendor: 123,
+			purposes: []int{1, 2, 3},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: false},
+			consentedVendors: map[int]bool{123: true},
+			numRestrictions: 0,
+			exp: false,
+		},
+		{
+			vendor: 123,
+			purposes: []int{1, 2, 3},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: false},
+			consentedVendors: map[int]bool{123: false},
+			numRestrictions: 1,
+			restrictions: []*iabconsent.PubRestrictionEntry{
+				{
+					PurposeID: 3,
+					RestrictionType: iabconsent.PurposeFlatlyNotAllowed,
+					NumEntries: 1,
+					RestrictionsRange: []*iabconsent.RangeEntry{
+						{
+							StartVendorID: 123,
+							EndVendorID: 123,
+						},
+					},
+				},
+			},
+			exp: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Log(tc)
+
+		var pc = &iabconsent.V2ParsedConsent{
+			PurposesConsent: tc.consentedPurposes,
+			ConsentedVendors: tc.consentedVendors,
+			NumPubRestrictions: tc.numRestrictions,
+			PubRestrictionEntries: tc.restrictions,
+		}
+
+		c.Check(pc.SuitableToProcess(tc.purposes, tc.vendor), check.Equals, tc.exp)
+	}
+}
+
 var _ = check.Suite(&V2ParsedConsentSuite{})

--- a/v2_parsed_consent_test.go
+++ b/v2_parsed_consent_test.go
@@ -315,7 +315,7 @@ func (v  *V2ParsedConsentSuite) TestSuitableToProcess(c *check.C) {
 		{
 			vendor: 123,
 			purposes: []int{1, 2, 3},
-			consentedPurposes: map[int]bool{1: true, 2: true, 3: false},
+			consentedPurposes: map[int]bool{1: true, 2: true, 3: true},
 			consentedVendors: map[int]bool{123: false},
 			numRestrictions: 1,
 			restrictions: []*iabconsent.PubRestrictionEntry{


### PR DESCRIPTION
Given discussions with our data ethics team we have come up with what we think the proper logic is for determining whether it is legal to process data in both v1 and v2 based on the bases of consented (or opted-in) purposes. It's worth noting that the v2 library does NOT have any built in logic for determining whether its legal to process on the basis of legitimate interest (as LiveRamp will not be doing this). We may chose to add this in later (or would be open to a PR to support this).

I also have added tests for all of these methods (old and new) and am fairly embarrassed they didn't already exist (for the older methods).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/iabconsent/15)
<!-- Reviewable:end -->
