### PR TITLE
[PX-2253] Function to get the minor version of a TCF v2 String

### DIFF
--- a/v2_parsed_consent_test.go
+++ b/v2_parsed_consent_test.go
@@ -411,4 +411,65 @@ func (v *V2ParsedConsentSuite) TestSuitableToProcess(c *check.C) {
 	}
 }
 
+func (v *V2ParsedConsentSuite) TestMinorVersion(c *check.C) {
+	var tcs = []struct {
+		desc          string
+		consentString string
+		minorVersion  int
+		err           string
+	}{
+		{
+			desc:          "TCFPolicyVersion of 0",
+			consentString: "CPu5aAAPu5aAAPoABABGCyAAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA",
+			minorVersion:  0,
+		},
+		{
+			desc:          "TCFPolicyVersion of 1",
+			consentString: "CPu5aAAPu5aAAPoABABGCyBAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA",
+			minorVersion:  0,
+		},
+		{
+			desc:          "TCFPolicyVersion of 2",
+			consentString: "CPu1ErgPu1ErgF4AAAENCZCAAAAAAAAAACiQAAAAAAAA.II7Nd_X__bX9n-_7_6ft0eY1f9_r37uQzDhfNs-8F3L_W_LwX32E7NF36tq4KmR4ku1bBIQNtHMnUDUmxaolVrzHsak2cpyNKJ_JkknsZe2dYGF9Pn9lD-YKZ7_5_9_f52T_9_9_-39z3_9f___dv_-__-vjf_599n_v9fV_78_Kf9______-____________8A",
+			minorVersion:  0,
+		},
+		{
+			desc:          "TCFPolicyVersion of 3",
+			consentString: "CPu5aAAPu5aAAPoABABGCyDAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA",
+			minorVersion:  1,
+		},
+		{
+			desc:          "TCFPolicyVersion of 4",
+			consentString: "CPuy0IAPuy0IAPoABABGCyEAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA",
+			minorVersion:  2,
+		},
+		{
+			consentString: "CAAAACgAAAAygAfB7DDEACEgAP_gAAAAAAYgAhQAwAEAAlACEAAAAAA",
+			minorVersion:  2,
+		},
+		{
+			consentString: "CPuy0IAPuy0IAPoABABGCyFAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA",
+			minorVersion:  100,
+			err:           "Unsupported TCFPolicyVersion 5",
+		},
+	}
+
+	for _, tc := range tcs {
+		var (
+			parsed       *iabconsent.V2ParsedConsent
+			minorVersion int
+			err          error
+		)
+		parsed, err = iabconsent.ParseV2(tc.consentString)
+		c.Check(err, check.IsNil)
+		minorVersion, err = parsed.MinorVersion()
+		if tc.err == "" {
+			c.Check(err, check.IsNil)
+		} else {
+			c.Check(err, check.ErrorMatches, tc.err)
+		}
+		c.Check(minorVersion, check.Equals, tc.minorVersion)
+	}
+}
+
 var _ = check.Suite(&V2ParsedConsentSuite{})


### PR DESCRIPTION
[JIRA Ticket](https://liveramp.atlassian.net/browse/PX-2253)

[Link](https://iabeurope.eu/wp-content/uploads/2023/07/July-FAQ_-TCF-v2.2-1.pdf) to document explaining the minor versions.

Specifically:
> **How to know which GVL version should be used when reading a TC String?**
>
>The Policy version should be used to understand which GVL must be used. If the Policy version
is 3 (TCF v2.1), the GVL for TCF 2.1 should be used (all archives can be found at
https://vendor-list.consensu.org/v2/archives/vendor-list-v{vendor-list-version}.json). If the Policy
version is 4 (TCF v2.2), the GVL for TCF 2.2 should be used (all archives will be made available
at https://vendor-list.consensu.org/v3/archives/vendor-list-v{vendor-list-version}.json).