### PR TITLE
[SPIKE] Handle Subsection Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea

--- a/gpp_parsed_consent_fixture_test.go
+++ b/gpp_parsed_consent_fixture_test.go
@@ -6,7 +6,7 @@ import (
 
 // Test fixtures can be created here: https://iabgpp.com/
 var gppParsedConsentFixtures = map[string]map[int]*iabconsent.MspaParsedConsent{
-	// Valid GPP w/ US National MSPA, No Subsection (is thesame as false GPC subsection.
+	// Valid GPP w/ US National MSPA, No Subsection (is the same as false GPC subsection).
 	"DBABLA~BVVqAAEABCA": {iabconsent.UsNationalSID: mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.QA"]},
 	// Valid GPP w/ US National MSPA, Subsection of GPC False.
 	"DBABLA~BVVqAAEABCA.QA": {iabconsent.UsNationalSID: mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.QA"]},

--- a/gpp_parsed_consent_test.go
+++ b/gpp_parsed_consent_test.go
@@ -178,9 +178,8 @@ func (s *MspaSuite) TestParseGppConsent(c *check.C) {
 
 func (s *MspaSuite) TestParseGppConsentError(c *check.C) {
 	tcs := []struct {
-		desc     string
-		gpp      string
-		expected error
+		desc string
+		gpp  string
 	}{
 		{
 			desc: "Empty Subsection.",

--- a/gpp_parsed_consent_test.go
+++ b/gpp_parsed_consent_test.go
@@ -128,23 +128,7 @@ func (s *MspaSuite) TestMapGppSectionToParser(c *check.C) {
 	}
 }
 
-func (s *MspaSuite) TestParseGppConsent(c *check.C) {
-	for g, e := range gppParsedConsentFixtures {
-		c.Log(g)
-
-		var p, err = iabconsent.ParseGppConsent(g)
-
-		c.Check(err, check.IsNil)
-		c.Check(p, check.HasLen, len(e))
-		for i, expected := range e {
-			parsed, found := p[i]
-			c.Check(found, check.Equals, true)
-			c.Check(parsed, check.DeepEquals, expected)
-		}
-	}
-}
-
-func (s *MspaSuite) TestParseGppErrors(c *check.C) {
+func (s *MspaSuite) TestMapGppSectionToParserErrors(c *check.C) {
 	tcs := []struct {
 		desc     string
 		gpp      string
@@ -176,17 +160,60 @@ func (s *MspaSuite) TestParseGppErrors(c *check.C) {
 	}
 }
 
+func (s *MspaSuite) TestParseGppConsent(c *check.C) {
+	for g, e := range gppParsedConsentFixtures {
+		c.Log(g)
+
+		var p, err = iabconsent.ParseGppConsent(g)
+
+		c.Check(err, check.IsNil)
+		c.Check(p, check.HasLen, len(e))
+		for i, expected := range e {
+			parsed, found := p[i]
+			c.Check(found, check.Equals, true)
+			c.Check(parsed, check.DeepEquals, expected)
+		}
+	}
+}
+
+func (s *MspaSuite) TestParseGppConsentError(c *check.C) {
+	tcs := []struct {
+		desc     string
+		gpp      string
+		expected error
+	}{
+		{
+			desc: "Empty Subsection.",
+			gpp:  "DBABzw~1YNN~BVVqAAEABCA.",
+		},
+		{
+			desc: "Empty Subsection.",
+			gpp:  "DBABAw~Bqqqqqqo.",
+		},
+	}
+	for _, tc := range tcs {
+		c.Log(tc.desc)
+
+		var p, err = iabconsent.ParseGppConsent(tc.gpp)
+
+		// Despite an error in the underlying parsing, we quietly do not add the bad value to the map.
+		c.Check(err, check.IsNil)
+		c.Check(p, check.HasLen, 0)
+	}
+}
+
 func (s *GppParseSuite) TestParseGppSubSections(c *check.C) {
 	var tcs = []struct {
-		description string
-		subsections string
-		expected    *iabconsent.GppSubSection
+		description        string
+		subsections        string
+		expectedSubsection *iabconsent.GppSubSection
+		expectedError      error
 	}{
 		{
 			description: "GPC Type, false value",
 			// 01000000
 			subsections: "QA",
-			expected: &iabconsent.GppSubSection{
+			expectedSubsection: &iabconsent.GppSubSection{
 				Gpc: false,
 			},
 		},
@@ -194,7 +221,7 @@ func (s *GppParseSuite) TestParseGppSubSections(c *check.C) {
 			description: "GPC Type, true value.",
 			// 01100000
 			subsections: "YA",
-			expected: &iabconsent.GppSubSection{
+			expectedSubsection: &iabconsent.GppSubSection{
 				Gpc: true,
 			},
 		},
@@ -202,7 +229,7 @@ func (s *GppParseSuite) TestParseGppSubSections(c *check.C) {
 			description: "No GPC Type.",
 			// 00000000
 			subsections: "AA",
-			expected: &iabconsent.GppSubSection{
+			expectedSubsection: &iabconsent.GppSubSection{
 				Gpc: false,
 			},
 		},
@@ -210,7 +237,7 @@ func (s *GppParseSuite) TestParseGppSubSections(c *check.C) {
 			description: "GPC True, then GPC False, should remain True.",
 			// 01100000.01000000
 			subsections: "YA.QA",
-			expected: &iabconsent.GppSubSection{
+			expectedSubsection: &iabconsent.GppSubSection{
 				Gpc: true,
 			},
 		},
@@ -218,9 +245,16 @@ func (s *GppParseSuite) TestParseGppSubSections(c *check.C) {
 			description: "GPC False, then GPC True, should remain True.",
 			// 01000000.01100000
 			subsections: "QA.YA",
-			expected: &iabconsent.GppSubSection{
+			expectedSubsection: &iabconsent.GppSubSection{
 				Gpc: true,
 			},
+		},
+		{
+			description: "GPC Error.",
+			// Blank value
+			subsections:        "",
+			expectedSubsection: nil,
+			expectedError:      errors.New("parse gpp subsection type: read int: read bits (index=0, length=2): bits: index out of range"),
 		},
 	}
 
@@ -229,8 +263,12 @@ func (s *GppParseSuite) TestParseGppSubSections(c *check.C) {
 		// There may be >1 subsections, and func expects them as an array, so split.
 		subsect := strings.Split(tc.subsections, ".")
 		var g, err = iabconsent.ParseGppSubSections(subsect)
-		c.Check(err, check.IsNil)
-		c.Check(g, check.DeepEquals, tc.expected)
+		if tc.expectedError == nil {
+			c.Check(err, check.IsNil)
+		} else {
+			c.Check(err.Error(), check.Equals, tc.expectedError.Error())
+		}
+		c.Check(g, check.DeepEquals, tc.expectedSubsection)
 	}
 }
 

--- a/mspa_sections.go
+++ b/mspa_sections.go
@@ -153,7 +153,10 @@ func (m *MspaUsNational) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -197,7 +200,10 @@ func (m *MspaUsCA) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -239,7 +245,10 @@ func (m *MspaUsVA) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -281,7 +290,10 @@ func (m *MspaUsCO) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -324,7 +336,10 @@ func (m *MspaUsUT) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -366,7 +381,10 @@ func (m *MspaUsCT) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -409,7 +427,10 @@ func (m *MspaUsFL) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -452,7 +473,10 @@ func (m *MspaUsMT) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -495,7 +519,10 @@ func (m *MspaUsOR) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -538,7 +565,10 @@ func (m *MspaUsTX) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -581,7 +611,10 @@ func (m *MspaUsDE) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -622,7 +655,10 @@ func (m *MspaUsIA) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -663,7 +699,10 @@ func (m *MspaUsNE) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -704,7 +743,10 @@ func (m *MspaUsNH) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -745,7 +787,10 @@ func (m *MspaUsNJ) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 
@@ -785,7 +830,10 @@ func (m *MspaUsTN) ParseConsent() (GppParsedConsent, error) {
 
 	if len(segments) > 1 {
 		var gppSubsectionConsent *GppSubSection
-		gppSubsectionConsent, _ = ParseGppSubSections(segments[1:])
+		gppSubsectionConsent, err = ParseGppSubSections(segments[1:])
+		if err != nil {
+			return p, err
+		}
 		p.Gpc = gppSubsectionConsent.Gpc
 	}
 


### PR DESCRIPTION
@shkumar-viantinc flagged that subsection parsing could return a null GPC section when the subsection could be invalid.  Therefore, we want to pass down that error, so that it is not added to map of successful consent strings.

Additional work on top of [this PR](https://github.com/LiveRamp/iabconsent/pull/33) to show tests and test fixtures for the behavior.