### PR TITLE
[PXS-2689] US Nat consent string v2 update

### DIFF
--- a/gpp_parsed_consent_fixture_test.go
+++ b/gpp_parsed_consent_fixture_test.go
@@ -24,7 +24,7 @@ var gppParsedConsentFixtures = map[string]map[int]*iabconsent.MspaParsedConsent{
 	"DBABFg~BVaGGGCA": {iabconsent.UsUtahSID: mspaConsentFixtures[iabconsent.UsUtahSID]["BVaGGGCA.QA"]},
 	// Valid GPP w/ US Connecticut MSPA, Subsection of GPC False.
 	"DBABVg~BVoYYYQg": {iabconsent.UsConnecticutSID: mspaConsentFixtures[iabconsent.UsConnecticutSID]["BVoYYYQg"]},
-	// Valid GPP w/ US National and Virgina MSPA, Subsection of GPC False.
+	// Valid GPP w/ US National and Virginia MSPA, Subsection of GPC False.
 	"DBACLMA~BVVqAAEABCA~BVoYYYI": {
 		iabconsent.UsNationalSID: mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.QA"],
 		iabconsent.UsVirginiaSID: mspaConsentFixtures[iabconsent.UsVirginiaSID]["BVoYYYI"],
@@ -38,7 +38,7 @@ var gppParsedConsentFixtures = map[string]map[int]*iabconsent.MspaParsedConsent{
 		iabconsent.UsUtahSID:        mspaConsentFixtures[iabconsent.UsUtahSID]["BVaGGGCA.QA"],
 		iabconsent.UsConnecticutSID: mspaConsentFixtures[iabconsent.UsConnecticutSID]["BVoYYYQg"],
 	},
-	// Valid GPP w/ US US National, California MSPA, Virgina MSPA, Colorado MSPA, Utah MSPA, Conneticut MSPA, Florida MSPA and Montana MSPA Subsection of GPC False.
+	// Valid GPP w/ US US National, California MSPA, Virginia MSPA, Colorado MSPA, Utah MSPA, Conneticut MSPA, Florida MSPA and Montana MSPA Subsection of GPC False.
 	"DBABrWA~BVVqAAEABCA~BVoYYZoI~BVoYYYI~BVoYYQg~BVaGGGCA~BVoYYYQg~Bqqqqqqo~Bqqqqqqo": {
 		iabconsent.UsNationalSID:    mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.QA"],
 		iabconsent.UsCaliforniaSID:  mspaConsentFixtures[iabconsent.UsCaliforniaSID]["BVoYYZoI"],

--- a/gpp_parsed_consent_fixture_test.go
+++ b/gpp_parsed_consent_fixture_test.go
@@ -29,7 +29,7 @@ var gppParsedConsentFixtures = map[string]map[int]*iabconsent.MspaParsedConsent{
 		iabconsent.UsNationalSID: mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.QA"],
 		iabconsent.UsVirginiaSID: mspaConsentFixtures[iabconsent.UsVirginiaSID]["BVoYYYI"],
 	},
-	// Valid GPP w/ US US National, California MSPA, Virgina MSPA, Colorado MSPA, and Utah Subsection of GPC False.
+	// Valid GPP w/ V1 US National, California MSPA, Virgina MSPA, Colorado MSPA, and Utah Subsection of GPC False.
 	"DBABrGA~BVVqAAEABCA~BVoYYZoI~BVoYYYI~BVoYYQg~BVaGGGCA~BVoYYYQg": {
 		iabconsent.UsNationalSID:    mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.QA"],
 		iabconsent.UsCaliforniaSID:  mspaConsentFixtures[iabconsent.UsCaliforniaSID]["BVoYYZoI"],
@@ -38,7 +38,7 @@ var gppParsedConsentFixtures = map[string]map[int]*iabconsent.MspaParsedConsent{
 		iabconsent.UsUtahSID:        mspaConsentFixtures[iabconsent.UsUtahSID]["BVaGGGCA.QA"],
 		iabconsent.UsConnecticutSID: mspaConsentFixtures[iabconsent.UsConnecticutSID]["BVoYYYQg"],
 	},
-	// Valid GPP w/ US US National, California MSPA, Virginia MSPA, Colorado MSPA, Utah MSPA, Conneticut MSPA, Florida MSPA and Montana MSPA Subsection of GPC False.
+	// Valid GPP w/ V1 US National, California MSPA, Virginia MSPA, Colorado MSPA, Utah MSPA, Conneticut MSPA, Florida MSPA and Montana MSPA Subsection of GPC False.
 	"DBABrWA~BVVqAAEABCA~BVoYYZoI~BVoYYYI~BVoYYQg~BVaGGGCA~BVoYYYQg~Bqqqqqqo~Bqqqqqqo": {
 		iabconsent.UsNationalSID:    mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.QA"],
 		iabconsent.UsCaliforniaSID:  mspaConsentFixtures[iabconsent.UsCaliforniaSID]["BVoYYZoI"],
@@ -52,7 +52,7 @@ var gppParsedConsentFixtures = map[string]map[int]*iabconsent.MspaParsedConsent{
 	// Valid GPP string w/ sections for EU TCF V2 and US Privacy
 	// Since both are not supported, Consent fixture should be blank.
 	"DBACNY~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA~1YNN": {},
-	// Valid GPP w/ US National MSPA and US Privacy, but skip US Privacy until supported.
+	// Valid GPP w/ V1 US National MSPA and US Privacy, but skip US Privacy until supported.
 	"DBABzw~1YNN~BVVqAAEABCA.QA": {7: mspaConsentFixtures[7]["BVVqAAEABCA.QA"]},
 	// Valid GPP w/ US Florida MSPA, Subsection of GPC False.
 	"DBABAw~Bqqqqqqo": {iabconsent.UsFloridaSID: mspaConsentFixtures[iabconsent.UsFloridaSID]["Bqqqqqqo"]},

--- a/gpp_parsed_consent_fixture_test.go
+++ b/gpp_parsed_consent_fixture_test.go
@@ -6,12 +6,14 @@ import (
 
 // Test fixtures can be created here: https://iabgpp.com/
 var gppParsedConsentFixtures = map[string]map[int]*iabconsent.MspaParsedConsent{
-	// Valid GPP w/ US National MSPA, No Subsection (is the same as false GPC subsection).
+	// Valid GPP w/ V1 US National MSPA, No Subsection (is the same as false GPC subsection).
 	"DBABLA~BVVqAAEABCA": {iabconsent.UsNationalSID: mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.QA"]},
-	// Valid GPP w/ US National MSPA, Subsection of GPC False.
+	// Valid GPP w/ V1 US National MSPA, Subsection of GPC False.
 	"DBABLA~BVVqAAEABCA.QA": {iabconsent.UsNationalSID: mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.QA"]},
-	// Valid GPP w/ US National MSPA, Subsection of GPC True.
+	// Valid GPP w/ V1 US National MSPA, Subsection of GPC True.
 	"DBABLA~BVVqAAEABCA.YA": {iabconsent.UsNationalSID: mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.YA"]},
+	// Valid GPP w/ V2 US National MSPA, Subsection of GPC True.
+	"DBABLA~CVVVVVVVVVVW.YA": {iabconsent.UsNationalSID: mspaConsentFixtures[iabconsent.UsNationalSID]["CVVVVVVVVVVW.YA"]},
 	// Valid GPP w/ US California MSPA, Subsection of GPC False.
 	"DBABBg~BVoYYZoI": {iabconsent.UsCaliforniaSID: mspaConsentFixtures[iabconsent.UsCaliforniaSID]["BVoYYZoI"]},
 	// Valid GPP w/ US Virginia MSPA, Subsection of GPC False.
@@ -22,7 +24,7 @@ var gppParsedConsentFixtures = map[string]map[int]*iabconsent.MspaParsedConsent{
 	"DBABFg~BVaGGGCA": {iabconsent.UsUtahSID: mspaConsentFixtures[iabconsent.UsUtahSID]["BVaGGGCA.QA"]},
 	// Valid GPP w/ US Connecticut MSPA, Subsection of GPC False.
 	"DBABVg~BVoYYYQg": {iabconsent.UsConnecticutSID: mspaConsentFixtures[iabconsent.UsConnecticutSID]["BVoYYYQg"]},
-	// Valid GPP w/ US US National and Virgina MSPA, Subsection of GPC False.
+	// Valid GPP w/ US National and Virgina MSPA, Subsection of GPC False.
 	"DBACLMA~BVVqAAEABCA~BVoYYYI": {
 		iabconsent.UsNationalSID: mspaConsentFixtures[iabconsent.UsNationalSID]["BVVqAAEABCA.QA"],
 		iabconsent.UsVirginiaSID: mspaConsentFixtures[iabconsent.UsVirginiaSID]["BVoYYYI"],

--- a/mspa_parsed_consent_fixture_test.go
+++ b/mspa_parsed_consent_fixture_test.go
@@ -11,7 +11,7 @@ import (
 var mspaConsentFixtures = map[int]map[string]*iabconsent.MspaParsedConsent{
 	// UsNational
 	iabconsent.UsNationalSID: {
-		// usnat without false GPC subsection.
+		// usnat v1 without false GPC subsection.
 		"BVVqAAEABCA.QA": {
 			Version:                             1,
 			SharingNotice:                       iabconsent.NoticeProvided,
@@ -46,7 +46,7 @@ var mspaConsentFixtures = map[int]map[string]*iabconsent.MspaParsedConsent{
 			MspaOptOutOptionMode:    iabconsent.MspaNotApplicable,
 			MspaServiceProviderMode: iabconsent.MspaNo,
 		},
-		// usnat with true GPC subsection.
+		// usnat v1 with true GPC subsection.
 		"BVVqAAEABCA.YA": {
 			Version:                             1,
 			SharingNotice:                       iabconsent.NoticeProvided,
@@ -82,7 +82,7 @@ var mspaConsentFixtures = map[int]map[string]*iabconsent.MspaParsedConsent{
 			MspaServiceProviderMode: iabconsent.MspaNo,
 			Gpc:                     true,
 		},
-		// usnat without subsection.
+		// usnat v1 without subsection.
 		"BqqAqqqqqqA": {
 			Version:                             1,
 			SharingNotice:                       iabconsent.NoticeNotProvided,
@@ -118,7 +118,49 @@ var mspaConsentFixtures = map[int]map[string]*iabconsent.MspaParsedConsent{
 			MspaServiceProviderMode: iabconsent.MspaNo,
 			Gpc:                     false,
 		},
+		// usnat v2 with true GPC subsection.
+		"CVVVVVVVVVVW.YA": {
+			Version:                             2,
+			SharingNotice:                       iabconsent.NoticeProvided,
+			SaleOptOutNotice:                    iabconsent.NoticeProvided,
+			SharingOptOutNotice:                 iabconsent.NoticeProvided,
+			TargetedAdvertisingOptOutNotice:     iabconsent.NoticeProvided,
+			SensitiveDataProcessingOptOutNotice: iabconsent.NoticeProvided,
+			SensitiveDataLimitUseNotice:         iabconsent.NoticeProvided,
+			SaleOptOut:                          iabconsent.OptedOut,
+			SharingOptOut:                       iabconsent.OptedOut,
+			TargetedAdvertisingOptOut:           iabconsent.OptedOut,
+			SensitiveDataProcessingConsents: map[int]iabconsent.MspaConsent{
+				0:  iabconsent.NoConsent,
+				1:  iabconsent.NoConsent,
+				2:  iabconsent.NoConsent,
+				3:  iabconsent.NoConsent,
+				4:  iabconsent.NoConsent,
+				5:  iabconsent.NoConsent,
+				6:  iabconsent.NoConsent,
+				7:  iabconsent.NoConsent,
+				8:  iabconsent.NoConsent,
+				9:  iabconsent.NoConsent,
+				10: iabconsent.NoConsent,
+				11: iabconsent.NoConsent,
+				12: iabconsent.NoConsent,
+				13: iabconsent.NoConsent,
+				14: iabconsent.NoConsent,
+				15: iabconsent.NoConsent,
+			},
+			KnownChildSensitiveDataConsents: map[int]iabconsent.MspaConsent{
+				0: iabconsent.NoConsent,
+				1: iabconsent.NoConsent,
+				2: iabconsent.NoConsent,
+			},
+			PersonalDataConsents:    iabconsent.NoConsent,
+			MspaCoveredTransaction:  iabconsent.MspaYes,
+			MspaOptOutOptionMode:    iabconsent.MspaYes,
+			MspaServiceProviderMode: iabconsent.MspaYes,
+			Gpc:                     true,
+		},
 	},
+
 	// California
 	iabconsent.UsCaliforniaSID: {
 		// usca with subsection of GPC True.
@@ -728,15 +770,15 @@ var mspaConsentFixtures = map[int]map[string]*iabconsent.MspaParsedConsent{
 			SensitiveDataProcessingOptOutNotice: iabconsent.NoticeProvided,
 			SaleOptOut:                          iabconsent.OptedOut,
 			TargetedAdvertisingOptOut:           iabconsent.OptedOut,
-			SensitiveDataProcessingConsents: map[int]iabconsent.MspaConsent{
-				0: iabconsent.NoConsent,
-				1: iabconsent.NoConsent,
-				2: iabconsent.NoConsent,
-				3: iabconsent.NoConsent,
-				4: iabconsent.NoConsent,
-				5: iabconsent.NoConsent,
-				6: iabconsent.NoConsent,
-				7: iabconsent.NoConsent,
+			SensitiveDataProcessingOptOuts: map[int]iabconsent.MspaOptout{
+				0: iabconsent.OptedOut,
+				1: iabconsent.OptedOut,
+				2: iabconsent.OptedOut,
+				3: iabconsent.OptedOut,
+				4: iabconsent.OptedOut,
+				5: iabconsent.OptedOut,
+				6: iabconsent.OptedOut,
+				7: iabconsent.OptedOut,
 			},
 			KnownChildSensitiveDataConsents: map[int]iabconsent.MspaConsent{
 				0: iabconsent.NoConsent,
@@ -755,15 +797,15 @@ var mspaConsentFixtures = map[int]map[string]*iabconsent.MspaParsedConsent{
 			SensitiveDataProcessingOptOutNotice: iabconsent.NoticeProvided,
 			SaleOptOut:                          iabconsent.OptedOut,
 			TargetedAdvertisingOptOut:           iabconsent.OptedOut,
-			SensitiveDataProcessingConsents: map[int]iabconsent.MspaConsent{
-				0: iabconsent.NoConsent,
-				1: iabconsent.NoConsent,
-				2: iabconsent.NoConsent,
-				3: iabconsent.NoConsent,
-				4: iabconsent.NoConsent,
-				5: iabconsent.NoConsent,
-				6: iabconsent.NoConsent,
-				7: iabconsent.NoConsent,
+			SensitiveDataProcessingOptOuts: map[int]iabconsent.MspaOptout{
+				0: iabconsent.OptedOut,
+				1: iabconsent.OptedOut,
+				2: iabconsent.OptedOut,
+				3: iabconsent.OptedOut,
+				4: iabconsent.OptedOut,
+				5: iabconsent.OptedOut,
+				6: iabconsent.OptedOut,
+				7: iabconsent.OptedOut,
 			},
 			KnownChildSensitiveDataConsents: map[int]iabconsent.MspaConsent{
 				0: iabconsent.NoConsent,

--- a/mspa_parsed_consent_test.go
+++ b/mspa_parsed_consent_test.go
@@ -224,8 +224,13 @@ func (s *MspaSuite) TestParseMSPAError(c *check.C) {
 			expected:      "parse %s consent string: illegal base64 data at input byte 0",
 		},
 		{
-			desc:          "Invalid Section Length",
+			desc:          "Invalid Section Length. Too long for all v1 strings",
 			consentString: "BqqAqqqqqqqqAA",
+			expected:      "invalid consent string length for v1",
+		},
+		{
+			desc:          "Invalid Section Length. Too short for all v1 strings",
+			consentString: "BqqA",
 			expected:      "invalid consent string length for v1",
 		},
 	}

--- a/mspa_parsed_consent_test.go
+++ b/mspa_parsed_consent_test.go
@@ -216,7 +216,7 @@ func (s *MspaSuite) TestParseMSPAError(c *check.C) {
 		{
 			desc:          "Wrong Version.",
 			consentString: "DVVqAAEABA",
-			expected:      "non-v1 string passed.",
+			expected:      "unsupported version: 3",
 		},
 		{
 			desc:          "Bad Decoding.",

--- a/mspa_parsed_consent_test.go
+++ b/mspa_parsed_consent_test.go
@@ -223,6 +223,11 @@ func (s *MspaSuite) TestParseMSPAError(c *check.C) {
 			consentString: "$%&*(",
 			expected:      "parse %s consent string: illegal base64 data at input byte 0",
 		},
+		{
+			desc:          "Invalid Section Length",
+			consentString: "BqqAqqqqqqqqAA",
+			expected:      "invalid consent string length for v1",
+		},
 	}
 	for _, s := range mspaTests {
 		for _, t := range tcs {

--- a/mspa_sections.go
+++ b/mspa_sections.go
@@ -8,6 +8,43 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// MspaUsNationalV1StringLength is 60 bits padded with 4 bits of 0s making valid length 64 bits
+	MspaUsNationalV1StringLength = 64
+	// MspaUsNationalV2StringLength is 70 bits padded with 2 bits of 0s making valid length 72 bits
+	MspaUsNationalV2StringLength = 72
+	// MspaUsCaV1StringLength is 46 bits padded with 2 bits of 0s making valid length 48 bits
+	MspaUsCaV1StringLength = 48
+	// MspaUsVaV1StringLength is 40 bits no padding needed
+	MspaUsVaV1StringLength = 40
+	// MspaUsCoV1StringLength is 38 bits padded with 2 bits of 0s making valid length 40 bits
+	MspaUsCoV1StringLength = 40
+	// MspaUsUtV1StringLength is 42 bits padded with 6 bits of 0s making valid length 48 bits
+	MspaUsUtV1StringLength = 48
+	// MspaUsCtV1StringLength is 44 bits padded with 4 bits of 0s making valid length 48 bits
+	MspaUsCtV1StringLength = 48
+	// MspaUsFlV1StringLength is 46 bits padded with 2 bits of 0s making valid length 48 bits
+	MspaUsFlV1StringLength = 48
+	// MspaUsMtV1StringLength is 46 bits padded with 2 bits of 0s making valid length 48 bits
+	MspaUsMtV1StringLength = 48
+	// MspaUsOrV1StringLength is 52 bits padded with 4 bits of 0s making valid length 56 bits
+	MspaUsOrV1StringLength = 56
+	// MspaUsTxV1StringLength is 42 bits padded with 6 bits of 0s making valid length 48 bits
+	MspaUsTxV1StringLength = 48
+	// MspaUsDeV1StringLength is 52 bits padded with 4 bits of 0s making valid length 56 bits
+	MspaUsDeV1StringLength = 56
+	// MspaUsIaV1StringLength is 42 bits padded with 6 bits of 0s making valid length 48 bits
+	MspaUsIaV1StringLength = 48
+	// MspaUsNeV1StringLength is 42 bits padded with 6 bits of 0s making valid length 48 bits
+	MspaUsNeV1StringLength = 48
+	// MspaUsNhV1StringLength is 46 bits padded with 2 bits of 0s making valid length 48 bits
+	MspaUsNhV1StringLength = 48
+	// MspaUsNjV1StringLength is 54 bits padded with 2 bits of 0s making valid length 48 bits
+	MspaUsNjV1StringLength = 56
+	// MspaUsTnV1StringLength is 40 bits with no padding making valid length 40 bits
+	MspaUsTnV1StringLength = 40
+)
+
 type MspaUsNational struct {
 	GppSection
 }
@@ -136,11 +173,10 @@ func (m *MspaUsNational) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1 and v2
-	// length of v1 is 60 bits padded with 4 bits of 0s making valid length 64 bits
-	// length of v2 is 70 bits padded with 2 bits of 0s making valid length 72 bits
-	if p.Version == 1 && r.Size() != 64 {
+
+	if p.Version == 1 && r.Size() != MspaUsNationalV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
-	} else if p.Version == 2 && r.Size() != 72 {
+	} else if p.Version == 2 && r.Size() != MspaUsNationalV2StringLength {
 		return nil, errors.New("invalid consent string length for v2")
 	}
 
@@ -202,8 +238,7 @@ func (m *MspaUsCA) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 46 bits padded with 2 bits of 0s making valid length 48 bits
-	if p.Version == 1 && r.Size() != 48 {
+	if p.Version == 1 && r.Size() != MspaUsCaV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -255,8 +290,7 @@ func (m *MspaUsVA) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 40 bits no padding needed
-	if p.Version == 1 && r.Size() != 40 {
+	if p.Version == 1 && r.Size() != MspaUsVaV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -306,8 +340,7 @@ func (m *MspaUsCO) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 38 bits with 2 bits of padding making valid length 40 bits
-	if p.Version == 1 && r.Size() != 40 {
+	if p.Version == 1 && r.Size() != MspaUsCoV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -357,8 +390,7 @@ func (m *MspaUsUT) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 42 bits with 6 bits of padding making valid length 48 bits
-	if p.Version == 1 && r.Size() != 48 {
+	if p.Version == 1 && r.Size() != MspaUsUtV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -409,8 +441,7 @@ func (m *MspaUsCT) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 44 bits with 4 bits of padding making valid length 48 bits
-	if p.Version == 1 && r.Size() != 48 {
+	if p.Version == 1 && r.Size() != MspaUsCtV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -460,8 +491,7 @@ func (m *MspaUsFL) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 46 bits with 2 bits of padding making valid length 48 bits
-	if p.Version == 1 && r.Size() != 48 {
+	if p.Version == 1 && r.Size() != MspaUsFlV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -512,8 +542,7 @@ func (m *MspaUsMT) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 46 bits with 2 bits of padding making valid length 48 bits
-	if p.Version == 1 && r.Size() != 48 {
+	if p.Version == 1 && r.Size() != MspaUsMtV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -564,8 +593,7 @@ func (m *MspaUsOR) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 52 bits with 4 bits of padding making valid length 56 bits
-	if p.Version == 1 && r.Size() != 56 {
+	if p.Version == 1 && r.Size() != MspaUsOrV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -616,8 +644,7 @@ func (m *MspaUsTX) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 42 bits with 6 bits of padding making valid length 48 bits
-	if p.Version == 1 && r.Size() != 48 {
+	if p.Version == 1 && r.Size() != MspaUsTxV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -668,8 +695,7 @@ func (m *MspaUsDE) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 52 bits with 4 bits of padding making valid length 56 bits
-	if p.Version == 1 && r.Size() != 56 {
+	if p.Version == 1 && r.Size() != MspaUsDeV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -721,8 +747,7 @@ func (m *MspaUsIA) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 42 bits with 6 bits of padding making valid length 48 bits
-	if p.Version == 1 && r.Size() != 48 {
+	if p.Version == 1 && r.Size() != MspaUsIaV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -771,8 +796,7 @@ func (m *MspaUsNE) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 42 bits with 6 bits of padding making valid length 48 bits
-	if p.Version == 1 && r.Size() != 48 {
+	if p.Version == 1 && r.Size() != MspaUsNeV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -821,8 +845,7 @@ func (m *MspaUsNH) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 46 bits with 2 bits of padding making valid length 48 bits
-	if p.Version == 1 && r.Size() != 48 {
+	if p.Version == 1 && r.Size() != MspaUsNhV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -871,8 +894,7 @@ func (m *MspaUsNJ) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 54 bits with 2 bits of padding making valid length 56 bits
-	if p.Version == 1 && r.Size() != 56 {
+	if p.Version == 1 && r.Size() != MspaUsNjV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 
@@ -921,8 +943,7 @@ func (m *MspaUsTN) ParseConsent() (GppParsedConsent, error) {
 	}
 
 	// validate the length of the bit string for v1
-	// length of v1 is 40 bits with no padding making valid length 40 bits
-	if p.Version == 1 && r.Size() != 40 {
+	if p.Version == 1 && r.Size() != MspaUsTnV1StringLength {
 		return nil, errors.New("invalid consent string length for v1")
 	}
 

--- a/mspa_sections.go
+++ b/mspa_sections.go
@@ -139,12 +139,11 @@ func (m *MspaUsNational) ParseConsent() (GppParsedConsent, error) {
 	// length of v1 is 60 bits padded with 4 bits of 0s making valid length 64 bits
 	// length of v2 is 70 bits padded with 2 bits of 0s making valid length 72 bits
 	if p.Version == 1 && r.Size() != 64 {
-		return nil, errors.New("invalid consent string length for v1. expected: 60 actual: " + fmt.Sprint(r.Size()))
+		return nil, errors.New("invalid consent string length for v1")
 	} else if p.Version == 2 && r.Size() != 72 {
-		return nil, errors.New("invalid consent string length for v2. expected: 70 actual: " + fmt.Sprint(r.Size()))
+		return nil, errors.New("invalid consent string length for v2")
 	}
 
-	// 18  bits
 	p.SharingNotice, _ = r.ReadMspaNotice()
 	p.SaleOptOutNotice, _ = r.ReadMspaNotice()
 	p.SharingOptOutNotice, _ = r.ReadMspaNotice()
@@ -157,15 +156,12 @@ func (m *MspaUsNational) ParseConsent() (GppParsedConsent, error) {
 
 	// see spec in IAB GPP repo for differences between v1 and v2
 	if p.Version == 1 {
-		// 24 + 4 = 28 bits
 		p.SensitiveDataProcessingConsents, _ = r.ReadMspaBitfieldConsent(12)
 		p.KnownChildSensitiveDataConsents, _ = r.ReadMspaBitfieldConsent(2)
 	} else if p.Version == 2 {
-		// 32 + 6 = 38 bits
 		p.SensitiveDataProcessingConsents, _ = r.ReadMspaBitfieldConsent(16)
 		p.KnownChildSensitiveDataConsents, _ = r.ReadMspaBitfieldConsent(3)
 	}
-	// 8 bits
 	p.PersonalDataConsents, _ = r.ReadMspaConsent()
 	p.MspaCoveredTransaction, _ = r.ReadMspaNaYesNo()
 	// 0 is not a valid value according to the docs for MspaCoveredTransaction. Instead of erroring,
@@ -203,6 +199,12 @@ func (m *MspaUsCA) ParseConsent() (GppParsedConsent, error) {
 
 	if p.Version != 1 {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
+	}
+
+	// validate the length of the bit string for v1
+	// length of v1 is 46 bits padded with 2 bits of 0s making valid length 48 bits
+	if p.Version == 1 && r.Size() != 48 {
+		return nil, errors.New("invalid consent string length for v1")
 	}
 
 	p.SaleOptOutNotice, _ = r.ReadMspaNotice()
@@ -252,6 +254,12 @@ func (m *MspaUsVA) ParseConsent() (GppParsedConsent, error) {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
 	}
 
+	// validate the length of the bit string for v1
+	// length of v1 is 40 bits no padding needed
+	if p.Version == 1 && r.Size() != 40 {
+		return nil, errors.New("invalid consent string length for v1")
+	}
+
 	p.SharingNotice, _ = r.ReadMspaNotice()
 	p.SaleOptOutNotice, _ = r.ReadMspaNotice()
 	p.TargetedAdvertisingOptOutNotice, _ = r.ReadMspaNotice()
@@ -297,6 +305,12 @@ func (m *MspaUsCO) ParseConsent() (GppParsedConsent, error) {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
 	}
 
+	// validate the length of the bit string for v1
+	// length of v1 is 38 bits with 2 bits of padding making valid length 40 bits
+	if p.Version == 1 && r.Size() != 40 {
+		return nil, errors.New("invalid consent string length for v1")
+	}
+
 	p.SharingNotice, _ = r.ReadMspaNotice()
 	p.SaleOptOutNotice, _ = r.ReadMspaNotice()
 	p.TargetedAdvertisingOptOutNotice, _ = r.ReadMspaNotice()
@@ -340,6 +354,12 @@ func (m *MspaUsUT) ParseConsent() (GppParsedConsent, error) {
 
 	if p.Version != 1 {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
+	}
+
+	// validate the length of the bit string for v1
+	// length of v1 is 42 bits with 6 bits of padding making valid length 48 bits
+	if p.Version == 1 && r.Size() != 48 {
+		return nil, errors.New("invalid consent string length for v1")
 	}
 
 	p.SharingNotice, _ = r.ReadMspaNotice()
@@ -388,6 +408,12 @@ func (m *MspaUsCT) ParseConsent() (GppParsedConsent, error) {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
 	}
 
+	// validate the length of the bit string for v1
+	// length of v1 is 44 bits with 4 bits of padding making valid length 48 bits
+	if p.Version == 1 && r.Size() != 48 {
+		return nil, errors.New("invalid consent string length for v1")
+	}
+
 	p.SharingNotice, _ = r.ReadMspaNotice()
 	p.SaleOptOutNotice, _ = r.ReadMspaNotice()
 	p.TargetedAdvertisingOptOutNotice, _ = r.ReadMspaNotice()
@@ -431,6 +457,12 @@ func (m *MspaUsFL) ParseConsent() (GppParsedConsent, error) {
 
 	if p.Version != 1 {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
+	}
+
+	// validate the length of the bit string for v1
+	// length of v1 is 46 bits with 2 bits of padding making valid length 48 bits
+	if p.Version == 1 && r.Size() != 48 {
+		return nil, errors.New("invalid consent string length for v1")
 	}
 
 	p.SharingNotice, _ = r.ReadMspaNotice()
@@ -479,6 +511,12 @@ func (m *MspaUsMT) ParseConsent() (GppParsedConsent, error) {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
 	}
 
+	// validate the length of the bit string for v1
+	// length of v1 is 46 bits with 2 bits of padding making valid length 48 bits
+	if p.Version == 1 && r.Size() != 48 {
+		return nil, errors.New("invalid consent string length for v1")
+	}
+
 	p.SharingNotice, _ = r.ReadMspaNotice()
 	p.SaleOptOutNotice, _ = r.ReadMspaNotice()
 	p.TargetedAdvertisingOptOutNotice, _ = r.ReadMspaNotice()
@@ -523,6 +561,12 @@ func (m *MspaUsOR) ParseConsent() (GppParsedConsent, error) {
 
 	if p.Version != 1 {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
+	}
+
+	// validate the length of the bit string for v1
+	// length of v1 is 52 bits with 4 bits of padding making valid length 56 bits
+	if p.Version == 1 && r.Size() != 56 {
+		return nil, errors.New("invalid consent string length for v1")
 	}
 
 	p.SharingNotice, _ = r.ReadMspaNotice()
@@ -571,6 +615,12 @@ func (m *MspaUsTX) ParseConsent() (GppParsedConsent, error) {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
 	}
 
+	// validate the length of the bit string for v1
+	// length of v1 is 42 bits with 6 bits of padding making valid length 48 bits
+	if p.Version == 1 && r.Size() != 48 {
+		return nil, errors.New("invalid consent string length for v1")
+	}
+
 	p.SharingNotice, _ = r.ReadMspaNotice()
 	p.SaleOptOutNotice, _ = r.ReadMspaNotice()
 	p.TargetedAdvertisingOptOutNotice, _ = r.ReadMspaNotice()
@@ -615,6 +665,12 @@ func (m *MspaUsDE) ParseConsent() (GppParsedConsent, error) {
 
 	if p.Version != 1 {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
+	}
+
+	// validate the length of the bit string for v1
+	// length of v1 is 52 bits with 4 bits of padding making valid length 56 bits
+	if p.Version == 1 && r.Size() != 56 {
+		return nil, errors.New("invalid consent string length for v1")
 	}
 
 	p.SharingNotice, _ = r.ReadMspaNotice()
@@ -664,6 +720,12 @@ func (m *MspaUsIA) ParseConsent() (GppParsedConsent, error) {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
 	}
 
+	// validate the length of the bit string for v1
+	// length of v1 is 42 bits with 6 bits of padding making valid length 48 bits
+	if p.Version == 1 && r.Size() != 48 {
+		return nil, errors.New("invalid consent string length for v1")
+	}
+
 	p.SharingNotice, _ = r.ReadMspaNotice()
 	p.SaleOptOutNotice, _ = r.ReadMspaNotice()
 	p.TargetedAdvertisingOptOutNotice, _ = r.ReadMspaNotice()
@@ -706,6 +768,12 @@ func (m *MspaUsNE) ParseConsent() (GppParsedConsent, error) {
 
 	if p.Version != 1 {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
+	}
+
+	// validate the length of the bit string for v1
+	// length of v1 is 42 bits with 6 bits of padding making valid length 48 bits
+	if p.Version == 1 && r.Size() != 48 {
+		return nil, errors.New("invalid consent string length for v1")
 	}
 
 	p.SharingNotice, _ = r.ReadMspaNotice()
@@ -752,6 +820,12 @@ func (m *MspaUsNH) ParseConsent() (GppParsedConsent, error) {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
 	}
 
+	// validate the length of the bit string for v1
+	// length of v1 is 46 bits with 2 bits of padding making valid length 48 bits
+	if p.Version == 1 && r.Size() != 48 {
+		return nil, errors.New("invalid consent string length for v1")
+	}
+
 	p.SharingNotice, _ = r.ReadMspaNotice()
 	p.SaleOptOutNotice, _ = r.ReadMspaNotice()
 	p.TargetedAdvertisingOptOutNotice, _ = r.ReadMspaNotice()
@@ -796,6 +870,12 @@ func (m *MspaUsNJ) ParseConsent() (GppParsedConsent, error) {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
 	}
 
+	// validate the length of the bit string for v1
+	// length of v1 is 54 bits with 2 bits of padding making valid length 56 bits
+	if p.Version == 1 && r.Size() != 56 {
+		return nil, errors.New("invalid consent string length for v1")
+	}
+
 	p.SharingNotice, _ = r.ReadMspaNotice()
 	p.SaleOptOutNotice, _ = r.ReadMspaNotice()
 	p.TargetedAdvertisingOptOutNotice, _ = r.ReadMspaNotice()
@@ -838,6 +918,12 @@ func (m *MspaUsTN) ParseConsent() (GppParsedConsent, error) {
 
 	if p.Version != 1 {
 		return nil, errors.New("unsupported version: " + fmt.Sprint(p.Version))
+	}
+
+	// validate the length of the bit string for v1
+	// length of v1 is 40 bits with no padding making valid length 40 bits
+	if p.Version == 1 && r.Size() != 40 {
+		return nil, errors.New("invalid consent string length for v1")
 	}
 
 	p.SharingNotice, _ = r.ReadMspaNotice()

--- a/mspa_sections.go
+++ b/mspa_sections.go
@@ -39,7 +39,7 @@ const (
 	MspaUsNeV1StringLength = 48
 	// MspaUsNhV1StringLength is 46 bits padded with 2 bits of 0s making valid length 48 bits
 	MspaUsNhV1StringLength = 48
-	// MspaUsNjV1StringLength is 54 bits padded with 2 bits of 0s making valid length 48 bits
+	// MspaUsNjV1StringLength is 54 bits padded with 2 bits of 0s making valid length 56 bits
 	MspaUsNjV1StringLength = 56
 	// MspaUsTnV1StringLength is 40 bits with no padding making valid length 40 bits
 	MspaUsTnV1StringLength = 40


### PR DESCRIPTION
[PXS-2689](https://liveramp.atlassian.net/browse/PXS-2689)

* Adding support for US National V2 consent string
* Adding checks to ensure strings match the expected lengths
* Fixed Iowa section to use opt-out bitfield over consents


## Call to envelope api with v1 prefix but v2 string length still passes. Fixing string to have v2 prefix returns 204
![Screenshot 2025-06-04 at 11 00 23 AM](https://github.com/user-attachments/assets/f29057ff-080e-4b56-80d3-3c4629951d64)


[PXS-2689]: https://liveramp.atlassian.net/browse/PXS-2689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ